### PR TITLE
Allow user custom fzf-tags's prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ Additionally, `fzf-tags` exposes a fuzzy `:tselect`. To replace the default `:ts
 ```vim
 noreabbrev <expr> ts getcmdtype() == ":" && getcmdline() == 'ts' ? 'FZFTselect' : 'ts'
 ```
+
+To replace the default prompt `🔎`:
+
+```vim
+let g:fzf_tags_prompt = "Gd "
+```

--- a/autoload/fzf_tags.vim
+++ b/autoload/fzf_tags.vim
@@ -32,10 +32,13 @@ function! fzf_tags#Find(identifier)
     execute 'tag' identifier
   else
     let expect_keys = join(keys(s:actions), ',')
+    if !exists('g:fzf_tags_prompt')
+      let g:fzf_tags_prompt = ' 🔎 '
+    endif
     call fzf#run({
     \   'source': source_lines,
     \   'sink*':   function('s:sink', [identifier]),
-    \   'options': '--expect=' . expect_keys . ' --ansi --no-sort --tiebreak index --prompt " 🔎 \"' . identifier . '\" > "',
+    \   'options': '--expect=' . expect_keys . ' --ansi --no-sort --tiebreak index --prompt "' . g:fzf_tags_prompt . '\"' . identifier . '\" > "',
     \   'down': '40%',
     \ })
   endif

--- a/autoload/fzf_tags.vim
+++ b/autoload/fzf_tags.vim
@@ -1,5 +1,9 @@
 scriptencoding utf-8
 
+if !exists('g:fzf_tags_prompt')
+  let g:fzf_tags_prompt = ' 🔎 '
+endif
+
 let s:actions = {
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',
@@ -32,9 +36,6 @@ function! fzf_tags#Find(identifier)
     execute 'tag' identifier
   else
     let expect_keys = join(keys(s:actions), ',')
-    if !exists('g:fzf_tags_prompt')
-      let g:fzf_tags_prompt = ' 🔎 '
-    endif
     call fzf#run({
     \   'source': source_lines,
     \   'sink*':   function('s:sink', [identifier]),


### PR DESCRIPTION
This plugin is awesome.
So I want it to be more configurable. This is the first one.
Hope you feel comfortable with it!
```vim
let g:fzf_tags_prompt = "Gd "
```
![2020-12-25_133247-810x475_scrot](https://user-images.githubusercontent.com/20609495/103123116-c13da680-46b5-11eb-81f4-26305a854516.png)