### PR TITLE
Allow using fzf-tags with identifier have suffix symbol

### DIFF
--- a/autoload/fzf_tags.vim
+++ b/autoload/fzf_tags.vim
@@ -21,7 +21,7 @@ function! fzf_tags#SelectCommand(identifier)
 endfunction
 
 function! fzf_tags#FindCommand(identifier)
-  return fzf_tags#Find(empty(a:identifier) ? expand('<cword>') : a:identifier)
+  return fzf_tags#Find(empty(a:identifier) ? s:get_identifier() : a:identifier)
 endfunction
 
 function! fzf_tags#Find(identifier)
@@ -107,6 +107,13 @@ function! s:sink(identifier, selection)
   " Go to tag!
   let l:count = split(selected_text)[0]
   execute l:count . 'tag' a:identifier
+endfunction
+
+" Get identifier like: is_it_method? instead of is_it_method
+function! s:get_identifier()
+  let suffix_symbols = '!?'
+  let identifier_pattern = '\' . expand('<cword>') . '[' .suffix_symbols . ']' . '\|' . expand('<cword>')
+  return matchstr(expand('<cWORD>'), identifier_pattern)
 endfunction
 
 function! s:green(s)


### PR DESCRIPTION
In Ruby sometime we write like this: `is_it_method?`
But <cword> doesn't contain `?`
So I just implement `s:get_identifier` to get identifier with suffix symbol.

**Before:**

![suffix-symbol-before](https://user-images.githubusercontent.com/20609495/103210186-8cd91d00-4937-11eb-80f0-dcddc222d1ee.png)

**After:**

- method with symbol

![syffix-symbol-after](https://user-images.githubusercontent.com/20609495/103210189-8ea2e080-4937-11eb-81dc-54839539e1b3.png)
- method without symbol

![suffix-symbol](https://user-images.githubusercontent.com/20609495/103210419-2ef90500-4938-11eb-97b3-02dc5c79bd69.png)