### PR TITLE
Fix vim opening in a file different from selected.

### DIFF
--- a/autoload/fzf_tags.vim
+++ b/autoload/fzf_tags.vim
@@ -53,6 +53,10 @@ function! s:tagstack_head()
   return stack.length != 0 ? stack.items[-1].tagname : ""
 endfunction
 
+function! s:tagsearch_string(identifier)
+  return '^' . a:identifier . '$'
+endfunction
+
 function! s:strip_leading_bangs(identifier)
   if (a:identifier[0] !=# '!')
     return a:identifier
@@ -62,8 +66,9 @@ function! s:strip_leading_bangs(identifier)
 endfunction
 
 function! s:source_lines(identifier)
+  let tagstring = s:tagsearch_string(a:identifier)
   let relevant_fields = map(
-  \   taglist('^' . a:identifier . '$', expand('%:p')),
+  \   taglist(tagstring, expand('%:p')),
   \   function('s:tag_to_string')
   \ )
   return map(s:align_lists(relevant_fields), 'join(v:val, " ")')
@@ -109,7 +114,7 @@ function! s:sink(identifier, selection)
 
   " Go to tag!
   let l:count = split(selected_text)[0]
-  execute l:count . 'tag' a:identifier
+  execute l:count . 'tag /' . s:tagsearch_string(a:identifier)
 endfunction
 
 function! s:green(s)


### PR DESCRIPTION
Use consistent tag search string for taglist and tags commands.

Fixes issue #19

FZF uses ^tag<identifier>$ to collect taglist output
This selected member for this is used as <id#>tag <identifer> to jump
The issue is taglist uses a different string while tag jump uses a different identifier string.
Hence tag lands in a different file than selected.
